### PR TITLE
Ruby Build will now keep ruby headers for gems that need it

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages the ruby-build framework and its installed rubies. A LWRP is also defined."
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "0.8.1"
+version           "0.8.2"
 
 supports "ubuntu"
 supports "debian"

--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -49,8 +49,9 @@ def perform_install
 
     rubie       = @rubie        # bypass block scoping issue
     prefix_path = @prefix_path  # bypass block scoping issue
+    keep_headers = '-k'         # this will force ruby-build to keep ruby headers
     execute "ruby-build[#{rubie}]" do
-      command   %{/usr/local/bin/ruby-build "#{rubie}" "#{prefix_path}"}
+      command   %{/usr/local/bin/ruby-build "#{rubie}" "#{prefix_path}" "#{keep_headers}"}
       user        new_resource.user         if new_resource.user
       group       new_resource.group        if new_resource.group
       environment new_resource.environment  if new_resource.environment


### PR DESCRIPTION
Current ruby-build removes ruby headers after installation. To prevent this from happening you have to add a "-k" at the end of the command.

If you do believe that this should be configurable, I will modify my pull request, but IMHO it's useless to have a build installation that can't compile most of the gems.