### PR TITLE
support install ruby 2.1.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem 'rake'
-gem 'foodcritic'
+gem "foodcritic", "2.1.0"
 
 group :development do
   gem 'emeril'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email  "fnichol@nichol.ca"
 license           "Apache 2.0"
 description       "Manages the ruby-build framework and its installed rubies. A LWRP is also defined."
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           "0.8.1"
+version           "0.8.2"
 
 supports "ubuntu"
 supports "debian"

--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -74,7 +74,7 @@ end
 
 def install_ruby_dependencies
   case ::File.basename(new_resource.definition)
-  when /^\d\.\d\.\d-/, /^rbx-/, /^ree-/
+  when /^\d\.\d\.\d/, /^rbx-/, /^ree-/
     pkgs = node['ruby_build']['install_pkgs_cruby']
   when /^jruby-/
     pkgs = node['ruby_build']['install_pkgs_jruby']


### PR DESCRIPTION
1. support ruby 2.1.0
2. bump version
3. specify foodcritic to 2.1.0, the newest version will fail 
```
FC017: LWRP does not notify when updated: /Users/niedhui/workspace/ruby/chef-ruby_build/providers/ruby.rb:28)
```
