### PR TITLE
Install All Packages

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -30,8 +30,10 @@ cache_path  = Chef::Config['file_cache_path']
 src_path    = "#{cache_path}/ruby-build"
 
 unless mac_with_no_homebrew
-  Array(node['ruby_build']['install_pkgs']).each do |pkg|
-    package pkg
+  %w[pkgs git_pkgs pkgs_cruby pkgs_jruby].each do |package_path|
+    Array(node['ruby_build']["install_#{package_path}"]).each do |pkg|
+      package pkg
+    end
   end
 
   Array(node['ruby_build']['install_git_pkgs']).each do |pkg|


### PR DESCRIPTION
Not every package was being installed along with Ruby. This was resulting in this problem:

```
/home/deployer/.rbenv/versions/2.1.2/lib/ruby/2.1.0/irb/completion.rb:9:in `require': cannot load such file -- readline (LoadError)
```