### PR TITLE
Update dependencies to prevent build failure of ruby 2.1.2

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -45,7 +45,7 @@ when "debian", "ubuntu"
   node.set['ruby_build']['install_pkgs'] = %w{ tar bash curl }
   node.set['ruby_build']['install_git_pkgs'] = %w{ git-core }
   node.set['ruby_build']['install_pkgs_cruby'] =
-    %w{ build-essential bison openssl libreadline6 libreadline6-dev
+    %w{ build-essential bison openssl libreadline libreadline-dev
         zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-0
         libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev autoconf
         libc6-dev ssl-cert subversion }


### PR DESCRIPTION
Installing ruby 2.1.2 fails requesting installation of
libreadline-dev.