### PR TITLE
Fix ruby installation error

### DIFF
--- a/providers/ruby.rb
+++ b/providers/ruby.rb
@@ -74,7 +74,7 @@ end
 
 def install_ruby_dependencies
   case ::File.basename(new_resource.definition)
-  when /^\d\.\d\.\d-/, /^rbx-/, /^ree-/
+  when /^\d\.\d\.\d-?/, /^rbx-/, /^ree-/
     pkgs = node['ruby_build']['install_pkgs_cruby']
   when /^jruby-/
     pkgs = node['ruby_build']['install_pkgs_jruby']


### PR DESCRIPTION
Versions such as 2.1.2 are not matched correctly,
resulting in the required packages not being installed.